### PR TITLE
refactor: rename module by adding missing ovh prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ng-payment-method
+# Contributing to ng-ovh-payment-method
 
 This project accepts contributions. In order to contribute, you should
 pay attention to a few things:
@@ -17,8 +17,8 @@ The contributions should be submitted through Github Pull Requests.
 
 # Licensing for new files
 
-ng-payment-method is licensed under a BSD-3-Clause license. Anything
-contributed to ng-payment-method must be released under this license.
+ng-ovh-payment-method is licensed under a BSD-3-Clause license. Anything
+contributed to ng-ovh-payment-method must be released under this license.
 
 When introducing a new file into the project, please make sure it has a
 copyright header making clear under which license it's being released.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 > Help you to get payment methods from different OVH APIs
 
-[![Downloads](https://badgen.net/npm/dt/@ovh-ux/ng-payment-method)](https://npmjs.com/package/@ovh-ux/ng-payment-method) [![Dependencies](https://badgen.net/david/dep/ovh-ux/ng-payment-method)](https://npmjs.com/package/@ovh-ux/ng-payment-method?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/ng-payment-method)](https://npmjs.com/package/@ovh-ux/ng-payment-method?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
+[![Downloads](https://badgen.net/npm/dt/@ovh-ux/ng-ovh-payment-method)](https://npmjs.com/package/@ovh-ux/ng-ovh-payment-method) [![Dependencies](https://badgen.net/david/dep/ovh-ux/ng-ovh-payment-method)](https://npmjs.com/package/@ovh-ux/ng-ovh-payment-method?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/ng-ovh-payment-method)](https://npmjs.com/package/@ovh-ux/ng-ovh-payment-method?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
 
 ## Install
 
 ```sh
-yarn add @ovh-ux/ng-payment-method
+yarn add @ovh-ux/ng-ovh-payment-method
 ```
 
 ## Usage
 
 ```js
-import ovhAngularPaymentMethod from '@ovh-ux/ng-payment-method';
+import ngOvhPaymentMethod from '@ovh-ux/ng-ovh-payment-method';
 
-// add the ovhAngularPaymentMethod module as dependency of your angular project
+// add the ngOvhPaymentMethod module as dependency of your angular project
 angular
   .module('myApp', [
-    ovhAngularPaymentMethod,
+    ngOvhPaymentMethod,
   ])
   .config((ovhPaymentMethodProvider, constants) => {
     // set the target - this will tell to the component which APIs the component needs to call
@@ -34,7 +34,7 @@ yarn test
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-payment-method/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-payment-method/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-payment-method/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-payment-method/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@ovh-ux/ng-payment-method",
+  "name": "@ovh-ux/ng-ovh-payment-method",
   "version": "1.0.0-alpha.1",
-  "description": "OVH Payment Methods wrapper for angular",
+  "description": "OVH Payment Methods wrapper for AngularJS",
   "author": "OVH SAS",
   "license": "BSD-3-Clause",
-  "repository": "ovh-ux/ng-payment-method",
+  "repository": "ovh-ux/ng-ovh-payment-method",
   "keywords": [
     "payment",
     "method",
     "ovh"
   ],
   "main": "./dist/cjs/index.js",
-  "browser": "./dist/umd/ng-payment-method.js",
+  "browser": "./dist/umd/ng-ovh-payment-method.js",
   "scripts": {
     "build": "rollup -c",
     "prepare": "rollup -c",


### PR DESCRIPTION
## 💄 Rename module by adding missing `ovh` prefix

### Description of the Change

908d47e — refactor: rename module by adding missing ovh prefix

/cc @Jisay @marie-j 